### PR TITLE
Add Piwik JavaScrip tracking code

### DIFF
--- a/ar/index.shtml
+++ b/ar/index.shtml
@@ -187,5 +187,23 @@ id="screenshots">&nbsp;</span>
 	    2013 Novell, Inc. جميع الحقوق محفوظة.
  	  </p>
     </div>
+    <!-- Piwik -->
+    <script type="text/javascript">
+      var _paq = _paq || [];
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.www.opensuse.org"]);
+      _paq.push(["setDomains", ["*.www.opensuse.org"]]);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+      var u="//beans.opensuse.org/piwik/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', 10]);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <noscript><p><img src="//beans.opensuse.org/piwik/piwik.php?idsite=10" style="border:0;" alt="" /></p></noscript>
+    <!-- End Piwik Code -->
 </body>
 </html>

--- a/ca/index.shtml
+++ b/ca/index.shtml
@@ -191,5 +191,23 @@ Amèriques</a></li>
 	    &copy; 2013 SUSE LLC. Tots els drets reservats.
  	  </p>
     </div>
+    <!-- Piwik -->
+    <script type="text/javascript">
+      var _paq = _paq || [];
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.www.opensuse.org"]);
+      _paq.push(["setDomains", ["*.www.opensuse.org"]]);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+      var u="//beans.opensuse.org/piwik/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', 10]);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <noscript><p><img src="//beans.opensuse.org/piwik/piwik.php?idsite=10" style="border:0;" alt="" /></p></noscript>
+    <!-- End Piwik Code -->
 </body>
 </html>

--- a/cs/index.shtml
+++ b/cs/index.shtml
@@ -189,5 +189,23 @@ oficiální openSUSE výbavu. Trička, hrnky, čepice, tašky a spoustu dalšíh
 	    &copy; 2013 SUSE LLC. Všechna práva vyhrazena.
  	  </p>
     </div>
+    <!-- Piwik -->
+    <script type="text/javascript">
+      var _paq = _paq || [];
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.www.opensuse.org"]);
+      _paq.push(["setDomains", ["*.www.opensuse.org"]]);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+      var u="//beans.opensuse.org/piwik/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', 10]);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <noscript><p><img src="//beans.opensuse.org/piwik/piwik.php?idsite=10" style="border:0;" alt="" /></p></noscript>
+    <!-- End Piwik Code -->
 </body>
 </html>

--- a/da/index.shtml
+++ b/da/index.shtml
@@ -190,5 +190,22 @@ Asien</a></li>
 	    &copy; 2013 SUSE LLC. All Rights Reserved.
  	  </p>
     </div>
+    <script type="text/javascript">
+      var _paq = _paq || [];
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.www.opensuse.org"]);
+      _paq.push(["setDomains", ["*.www.opensuse.org"]]);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+      var u="//beans.opensuse.org/piwik/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', 10]);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <noscript><p><img src="//beans.opensuse.org/piwik/piwik.php?idsite=10" style="border:0;" alt="" /></p></noscript>
+    <!-- End Piwik Code -->
 </body>
 </html>

--- a/de/index.shtml
+++ b/de/index.shtml
@@ -190,5 +190,22 @@ Asien</a></li>
 	    &copy; 2013 SUSE LLC. Alle Rechte vorbehalten.
  	  </p>
     </div>
+    <script type="text/javascript">
+      var _paq = _paq || [];
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.www.opensuse.org"]);
+      _paq.push(["setDomains", ["*.www.opensuse.org"]]);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+      var u="//beans.opensuse.org/piwik/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', 10]);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <noscript><p><img src="//beans.opensuse.org/piwik/piwik.php?idsite=10" style="border:0;" alt="" /></p></noscript>
+    <!-- End Piwik Code -->
 </body>
 </html>

--- a/el/index.shtml
+++ b/el/index.shtml
@@ -193,5 +193,22 @@ href="http://en.opensuse.org/openSUSE:Mailing_lists">λίστες
 	    &copy; 2013 SUSE LLC. All Rights Reserved.
  	  </p>
     </div>
+    <script type="text/javascript">
+      var _paq = _paq || [];
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.www.opensuse.org"]);
+      _paq.push(["setDomains", ["*.www.opensuse.org"]]);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+      var u="//beans.opensuse.org/piwik/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', 10]);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <noscript><p><img src="//beans.opensuse.org/piwik/piwik.php?idsite=10" style="border:0;" alt="" /></p></noscript>
+    <!-- End Piwik Code -->
 </body>
 </html>

--- a/en/index.shtml
+++ b/en/index.shtml
@@ -192,5 +192,23 @@
 	    &copy; 2013 SUSE LLC. All Rights Reserved.
  	  </p>
     </div>
+    <!-- Piwik -->
+    <script type="text/javascript">
+      var _paq = _paq || [];
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.www.opensuse.org"]);
+      _paq.push(["setDomains", ["*.www.opensuse.org"]]);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+      var u="//beans.opensuse.org/piwik/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', 10]);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <noscript><p><img src="//beans.opensuse.org/piwik/piwik.php?idsite=10" style="border:0;" alt="" /></p></noscript>
+    <!-- End Piwik Code -->
 </body>
 </html>

--- a/es/index.shtml
+++ b/es/index.shtml
@@ -191,5 +191,23 @@ Asia</a></li>
 	    &copy; 2013 SUSE LLC. Todos los derechos reservados.
  	  </p>
     </div>
+    <!-- Piwik -->
+    <script type="text/javascript">
+      var _paq = _paq || [];
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.www.opensuse.org"]);
+      _paq.push(["setDomains", ["*.www.opensuse.org"]]);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+      var u="//beans.opensuse.org/piwik/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', 10]);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <noscript><p><img src="//beans.opensuse.org/piwik/piwik.php?idsite=10" style="border:0;" alt="" /></p></noscript>
+    <!-- End Piwik Code -->
 </body>
 </html>

--- a/fi/index.shtml
+++ b/fi/index.shtml
@@ -190,5 +190,22 @@ Asiassa</a></li>
 	    &copy; 2013 SUSE LLC. All Rights Reserved.
  	  </p>
     </div>
+    <script type="text/javascript">
+      var _paq = _paq || [];
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.www.opensuse.org"]);
+      _paq.push(["setDomains", ["*.www.opensuse.org"]]);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+      var u="//beans.opensuse.org/piwik/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', 10]);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <noscript><p><img src="//beans.opensuse.org/piwik/piwik.php?idsite=10" style="border:0;" alt="" /></p></noscript>
+    <!-- End Piwik Code -->
 </body>
 </html>

--- a/fr/index.shtml
+++ b/fr/index.shtml
@@ -193,5 +193,22 @@ l'Asie</a></li>
 	    &copy; 2013 SUSE LLC. Tous droits réservés.
  	  </p>
     </div>
+    <script type="text/javascript">
+      var _paq = _paq || [];
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.www.opensuse.org"]);
+      _paq.push(["setDomains", ["*.www.opensuse.org"]]);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+      var u="//beans.opensuse.org/piwik/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', 10]);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <noscript><p><img src="//beans.opensuse.org/piwik/piwik.php?idsite=10" style="border:0;" alt="" /></p></noscript>
+    <!-- End Piwik Code -->
 </body>
 </html>

--- a/hu/index.shtml
+++ b/hu/index.shtml
@@ -193,5 +193,22 @@ webáruház</a></li>
 	    &copy; 2013 SUSE LLC. All Rights Reserved.
  	  </p>
     </div>
+    <script type="text/javascript">
+      var _paq = _paq || [];
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.www.opensuse.org"]);
+      _paq.push(["setDomains", ["*.www.opensuse.org"]]);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+      var u="//beans.opensuse.org/piwik/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', 10]);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <noscript><p><img src="//beans.opensuse.org/piwik/piwik.php?idsite=10" style="border:0;" alt="" /></p></noscript>
+    <!-- End Piwik Code -->
 </body>
 </html>

--- a/it/index.shtml
+++ b/it/index.shtml
@@ -191,5 +191,22 @@ l'Asia</a></li>
 	    &copy; 2013 SUSE LLC. Tutti i diritti riservati.
  	  </p>
     </div>
+    <script type="text/javascript">
+      var _paq = _paq || [];
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.www.opensuse.org"]);
+      _paq.push(["setDomains", ["*.www.opensuse.org"]]);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+      var u="//beans.opensuse.org/piwik/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', 10]);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <noscript><p><img src="//beans.opensuse.org/piwik/piwik.php?idsite=10" style="border:0;" alt="" /></p></noscript>
+    <!-- End Piwik Code -->
 </body>
 </html>

--- a/jp/index.shtml
+++ b/jp/index.shtml
@@ -186,5 +186,22 @@ href="http://ja.opensuse.org/%E3%83%A1%E3%83%BC%E3%83%AA%E3%83%B3%E3%82%B0%E3%83
 	    &copy; 2013 SUSE LLC. All Rights Reserved.
  	  </p>
     </div>
+    <script type="text/javascript">
+      var _paq = _paq || [];
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.www.opensuse.org"]);
+      _paq.push(["setDomains", ["*.www.opensuse.org"]]);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+      var u="//beans.opensuse.org/piwik/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', 10]);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <noscript><p><img src="//beans.opensuse.org/piwik/piwik.php?idsite=10" style="border:0;" alt="" /></p></noscript>
+    <!-- End Piwik Code -->
 </body>
 </html>

--- a/lt/index.shtml
+++ b/lt/index.shtml
@@ -194,5 +194,22 @@ Azijoje</a></li>
 	    &copy; 2013 SUSE LLC. Visos teisės saugomos.
  	  </p>
     </div>
+    <script type="text/javascript">
+      var _paq = _paq || [];
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.www.opensuse.org"]);
+      _paq.push(["setDomains", ["*.www.opensuse.org"]]);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+      var u="//beans.opensuse.org/piwik/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', 10]);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <noscript><p><img src="//beans.opensuse.org/piwik/piwik.php?idsite=10" style="border:0;" alt="" /></p></noscript>
+    <!-- End Piwik Code -->
 </body>
 </html>

--- a/nb/index.shtml
+++ b/nb/index.shtml
@@ -189,5 +189,22 @@ Asia</a></li>
 	    &copy; 2013 SUSE LLC. Med enerett.
  	  </p>
     </div>
+    <script type="text/javascript">
+      var _paq = _paq || [];
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.www.opensuse.org"]);
+      _paq.push(["setDomains", ["*.www.opensuse.org"]]);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+      var u="//beans.opensuse.org/piwik/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', 10]);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <noscript><p><img src="//beans.opensuse.org/piwik/piwik.php?idsite=10" style="border:0;" alt="" /></p></noscript>
+    <!-- End Piwik Code -->
 </body>
 </html>

--- a/nl/index.shtml
+++ b/nl/index.shtml
@@ -189,5 +189,22 @@ nog veel meer.
 	    &copy; 2013 SUSE LLC. Alle rechten voorbehouden.
  	  </p>
     </div>
+    <script type="text/javascript">
+      var _paq = _paq || [];
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.www.opensuse.org"]);
+      _paq.push(["setDomains", ["*.www.opensuse.org"]]);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+      var u="//beans.opensuse.org/piwik/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', 10]);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <noscript><p><img src="//beans.opensuse.org/piwik/piwik.php?idsite=10" style="border:0;" alt="" /></p></noscript>
+    <!-- End Piwik Code -->
 </body>
 </html>

--- a/pl/index.shtml
+++ b/pl/index.shtml
@@ -189,5 +189,22 @@ azjatycki</a></li>
 	    &copy; 2013 SUSE LLC. All Rights Reserved.
  	  </p>
     </div>
+    <script type="text/javascript">
+      var _paq = _paq || [];
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.www.opensuse.org"]);
+      _paq.push(["setDomains", ["*.www.opensuse.org"]]);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+      var u="//beans.opensuse.org/piwik/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', 10]);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <noscript><p><img src="//beans.opensuse.org/piwik/piwik.php?idsite=10" style="border:0;" alt="" /></p></noscript>
+    <!-- End Piwik Code -->
 </body>
 </html>

--- a/pt-br/index.shtml
+++ b/pt-br/index.shtml
@@ -190,5 +190,22 @@ mais.
 	    &copy; 2013 SUSE LLC. Todos os direitos reservados.
  	  </p>
     </div>
+    <script type="text/javascript">
+      var _paq = _paq || [];
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.www.opensuse.org"]);
+      _paq.push(["setDomains", ["*.www.opensuse.org"]]);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+      var u="//beans.opensuse.org/piwik/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', 10]);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <noscript><p><img src="//beans.opensuse.org/piwik/piwik.php?idsite=10" style="border:0;" alt="" /></p></noscript>
+    <!-- End Piwik Code -->
 </body>
 </html>

--- a/ru/index.shtml
+++ b/ru/index.shtml
@@ -189,5 +189,22 @@ href="http://ru.opensuse.org/openSUSE:Список_доступных_рассы
 	    &copy; 2013 SUSE LLC. Все права защищены.
  	  </p>
     </div>
+    <script type="text/javascript">
+      var _paq = _paq || [];
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.www.opensuse.org"]);
+      _paq.push(["setDomains", ["*.www.opensuse.org"]]);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+      var u="//beans.opensuse.org/piwik/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', 10]);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <noscript><p><img src="//beans.opensuse.org/piwik/piwik.php?idsite=10" style="border:0;" alt="" /></p></noscript>
+    <!-- End Piwik Code -->
 </body>
 </html>

--- a/sk/index.shtml
+++ b/sk/index.shtml
@@ -190,5 +190,22 @@ oficiálne openSUSE vybavenie. Tričká, hrnčeky, čiapky, batohy a mnoho
 	    &copy; 2013 SUSE LLC. Všetky práva vyhradené.
  	  </p>
     </div>
+    <script type="text/javascript">
+      var _paq = _paq || [];
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.www.opensuse.org"]);
+      _paq.push(["setDomains", ["*.www.opensuse.org"]]);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+      var u="//beans.opensuse.org/piwik/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', 10]);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <noscript><p><img src="//beans.opensuse.org/piwik/piwik.php?idsite=10" style="border:0;" alt="" /></p></noscript>
+    <!-- End Piwik Code -->
 </body>
 </html>

--- a/th/index.shtml
+++ b/th/index.shtml
@@ -188,5 +188,22 @@ Asia</a></li>
 	    &copy; 2013 SUSE LLC. All Rights Reserved.
  	  </p>
     </div>
+    <script type="text/javascript">
+      var _paq = _paq || [];
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.www.opensuse.org"]);
+      _paq.push(["setDomains", ["*.www.opensuse.org"]]);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+      var u="//beans.opensuse.org/piwik/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', 10]);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <noscript><p><img src="//beans.opensuse.org/piwik/piwik.php?idsite=10" style="border:0;" alt="" /></p></noscript>
+    <!-- End Piwik Code -->
 </body>
 </html>

--- a/uk/index.shtml
+++ b/uk/index.shtml
@@ -189,5 +189,22 @@ href="http://en.opensuse.org/openSUSE:Mailing_lists">списків розсил
 	    &copy; 2013 SUSE LLC. Усі права захищені.
  	  </p>
     </div>
+    <script type="text/javascript">
+      var _paq = _paq || [];
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.www.opensuse.org"]);
+      _paq.push(["setDomains", ["*.www.opensuse.org"]]);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+      var u="//beans.opensuse.org/piwik/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', 10]);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <noscript><p><img src="//beans.opensuse.org/piwik/piwik.php?idsite=10" style="border:0;" alt="" /></p></noscript>
+    <!-- End Piwik Code -->
 </body>
 </html>

--- a/zh-cn/index.shtml
+++ b/zh-cn/index.shtml
@@ -181,5 +181,22 @@ href="http://en.opensuse.org/openSUSE:Mailing_lists">邮件列表</a>吧。
 	    &copy; 2013 SUSE, Inc. 保留一切权利。
  	  </p>
     </div>
+    <script type="text/javascript">
+      var _paq = _paq || [];
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.www.opensuse.org"]);
+      _paq.push(["setDomains", ["*.www.opensuse.org"]]);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+      var u="//beans.opensuse.org/piwik/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', 10]);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <noscript><p><img src="//beans.opensuse.org/piwik/piwik.php?idsite=10" style="border:0;" alt="" /></p></noscript>
+    <!-- End Piwik Code -->
 </body>
 </html>

--- a/zh-tw/index.shtml
+++ b/zh-tw/index.shtml
@@ -182,5 +182,22 @@ href="http://en.opensuse.org/openSUSE:Mailing_lists">郵件列表</a>。
 	    &copy; 2013 SUSE LLC. 版權所有。
  	  </p>
     </div>
+    <script type="text/javascript">
+      var _paq = _paq || [];
+      _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(["setCookieDomain", "*.www.opensuse.org"]);
+      _paq.push(["setDomains", ["*.www.opensuse.org"]]);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+      var u="//beans.opensuse.org/piwik/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', 10]);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <noscript><p><img src="//beans.opensuse.org/piwik/piwik.php?idsite=10" style="border:0;" alt="" /></p></noscript>
+    <!-- End Piwik Code -->
 </body>
 </html>


### PR DESCRIPTION
- Track visitors across all subdomains of www.o.o
- Prepend the site domain to the page title when tracking
- In the "Outlinks" report, hide clicks to known alias URLs of www.o.o
